### PR TITLE
Added UnityCBPeripheral in the OnUpdateValue handler

### DIFF
--- a/Unity/LibraryUser/Assets/Plugins/UnityCoreBluetooth/Scripts/UnityCoreBluetooth.cs
+++ b/Unity/LibraryUser/Assets/Plugins/UnityCoreBluetooth/Scripts/UnityCoreBluetooth.cs
@@ -125,24 +125,25 @@ namespace UnityCoreBluetoothFramework
 
         //unityCoreBluetooth_onUpdateValue ----------------------------------------------------------------------------------
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void unityCoreBluetooth_onUpdateValue_delegate(IntPtr characteristic, IntPtr data, long length);
+        public delegate void unityCoreBluetooth_onUpdateValue_delegate(IntPtr peripheral, IntPtr characteristic, IntPtr data, long length);
 
         [DllImport(UnityCoreBluetooth_bundle.IMPORT_TARGET)]
         private static extern void unityCoreBluetooth_onUpdateValue(IntPtr unityCoreBluetooth,
             unityCoreBluetooth_onUpdateValue_delegate handler);
 
-        private static event Action<UnityCBCharacteristic, byte[]> onUpdateValueHandler;
+        private static event Action<UnityCBPeripheral, UnityCBCharacteristic, byte[]> onUpdateValueHandler;
 
         [MonoPInvokeCallback(typeof(unityCoreBluetooth_onUpdateValue_delegate))]
-        private static void onUpdateValueCallback(IntPtr characteristic, IntPtr data, long length)
+        private static void onUpdateValueCallback(IntPtr peripheral, IntPtr characteristic, IntPtr data, long length)
         {
             UnityCBCharacteristic c = new UnityCBCharacteristic(characteristic);
+            UnityCBPeripheral p = new UnityCBPeripheral(peripheral);
             byte[] result = new byte[length];
             Marshal.Copy(data, result, 0, (int)length);
-            UnityCoreBluetooth.onUpdateValueHandler(c, result);
+            UnityCoreBluetooth.onUpdateValueHandler(p, c, result);
         }
 
-        public void OnUpdateValue(Action<UnityCBCharacteristic, byte[]> handler)
+        public void OnUpdateValue(Action<UnityCBPeripheral, UnityCBCharacteristic, byte[]> handler)
         {
             UnityCoreBluetooth.onUpdateValueHandler = handler;
         }

--- a/Xcode/Library/Sources/NativePlugin.h
+++ b/Xcode/Library/Sources/NativePlugin.h
@@ -23,7 +23,7 @@ typedef void (*OnDiscoverPeripheralHandler) (CBPeripheral* peripheral);
 typedef void (*OnConnectPeripheralHandler) (CBPeripheral* peripheral);
 typedef void (*OnDiscoverServiceHandler) (CBService* service);
 typedef void (*OnDiscoverCharacteristicHandler) (CBCharacteristic* characteristic);
-typedef void (*OnUpdateValueHandler) (CBCharacteristic* characteristic, unsigned char* data, long length);
+typedef void (*OnUpdateValueHandler) (CBPeripheral* peripheral, CBCharacteristic* characteristic, unsigned char* data, long length);
 
 #ifdef __cplusplus
 extern "C" {

--- a/Xcode/Library/Sources/NativePlugin.mm
+++ b/Xcode/Library/Sources/NativePlugin.mm
@@ -62,11 +62,11 @@ void unityCoreBluetooth_onDiscoverCharacteristic(UnityCoreBluetooth* unityCoreBl
 void unityCoreBluetooth_onUpdateValue(UnityCoreBluetooth* unityCoreBluetooth, OnUpdateValueHandler handler) {
     @autoreleasepool {
         if (unityCoreBluetooth == nil) return;
-        [unityCoreBluetooth onUpdateValueWithHandler: ^(CBCharacteristic* characteristic, NSData* data) {
+        [unityCoreBluetooth onUpdateValueWithHandler: ^(CBPeripheral* peripheral, CBCharacteristic* characteristic, NSData* data) {
             NSUInteger length = [data length];
             unsigned char* ptrDest = (unsigned char*)malloc(length);
             memcpy(ptrDest, [data bytes], length);
-            handler(characteristic, ptrDest, length);
+            handler(peripheral, characteristic, ptrDest, length);
             free(ptrDest);
         }];
     }

--- a/Xcode/Library/Sources/UnityCoreBluetooth.swift
+++ b/Xcode/Library/Sources/UnityCoreBluetooth.swift
@@ -131,8 +131,8 @@ public class UnityCoreBluetooth: NSObject {
         }
     }
     
-    private var onUpdateValueHandler: ((_ characteristic: CBCharacteristic, _ value: Data) -> Void)? = nil
-    public func onUpdateValue(handler: @escaping (_ characteristic: CBCharacteristic, _ value: Data) -> Void) {
+    private var onUpdateValueHandler: ((_ peripheral: CBPeripheral, _ characteristic: CBCharacteristic, _ value: Data) -> Void)? = nil
+    public func onUpdateValue(handler: @escaping (_ peripheral: CBPeripheral, _ characteristic: CBCharacteristic, _ value: Data) -> Void) {
         DispatchQueue.main.async { [weak self] in
             self?.onUpdateValueHandler = handler
         }
@@ -206,6 +206,6 @@ extension UnityCoreBluetooth: CBPeripheralDelegate {
     }
     
     public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        self.onUpdateValueHandler?(characteristic, characteristic.value ?? Data())
+        self.onUpdateValueHandler?(peripheral, characteristic, characteristic.value ?? Data())
     }
 }


### PR DESCRIPTION
This makes it possible to know which UnityCBPeripheral the value is coming from if there are multiple peripherals connected at the same time.

PS.
I'm not sure why git thinks I've changed the first 7 lines and last 2 of UnityCoreBluetooth.cs. I didn't change anything in those lines on purpose, perhaps the IDE did something...